### PR TITLE
Change hack-a-day to a page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,7 +3,8 @@ main:
   - title: "About"
     url: /
   - title: "Monthly Hack-a-day"
-    url: "/assets/calendar/NMIND monthly meeting.ics"
+    url: /hack/
+  # url: "/assets/calendar/NMIND monthly meeting.ics"
   # - title: "About"
   #   url: https://mmistakes.github.io/minimal-mistakes/about/
   # - title: "Sample Posts"

--- a/_pages/hack.md
+++ b/_pages/hack.md
@@ -1,5 +1,14 @@
+---
+title: "Monthly Hack-a-day"
+layout: single
+author_profile: false
+permalink: /hack/
+---
+
 The first Thursday of every month, NMIND gathers in [gather.town](https://www.google.com/url?q=https://gather.town/app/ESJPNXX7CVirKett/nmind) to collaborate on our current priorities.
 
 Location: https://gather.town/app/ESJPNXX7CVirKett/nmind
 
 Time: The first Thursday of every month effective 9/2/21 from 11:00 AM to 4:00 PM
+
+Download [Calendar](/assets/calendar/NMIND monthly meeting.ics)

--- a/hack-a-day.markdown
+++ b/hack-a-day.markdown
@@ -1,0 +1,5 @@
+The first Thursday of every month, NMIND gathers in [gather.town](https://www.google.com/url?q=https://gather.town/app/ESJPNXX7CVirKett/nmind) to collaborate on our current priorities.
+
+Location: https://gather.town/app/ESJPNXX7CVirKett/nmind
+
+Time: The first Thursday of every month effective 9/2/21 from 11:00 AM to 4:00 PM

--- a/index.markdown
+++ b/index.markdown
@@ -32,13 +32,11 @@ The widespread promotion and adoption of the NMIND collaborative standards and c
 get_involved:
   - excerpt: "## Community
 
-Join us in [Gather.town](https://www.google.com/url?q=https://gather.town/app/ESJPNXX7CVirKett/nmind) [the first Thursday of every month](/assets/calendar/NMIND monthly meeting.ics).
-
-Subscribe to our [Google Groups](https://groups.google.com/g/nmind).
+Join us in [Gather.town](https://www.google.com/url?q=https://gather.town/app/ESJPNXX7CVirKett/nmind) [the first Thursday of every month](/assets/calendar/NMIND monthly meeting.ics) and join our [Google Groups](https://groups.google.com/g/nmind).
 "
   - excerpt: "## Coding projects
 
-NMIND has the following GitHub projects
+NMIND has the following [GitHub](https://github.com/nmind) projects
 
 * [nmind.github.io](https://github.com/nmind/nmind.github.io) - The backing project for this website
 


### PR DESCRIPTION
## Resolves
<!-- If PR doesn't fully resolve the issue, replace 'Resolves' below with 'Related to'. -->
<!-- If there is no issue being resolved, consider opening one before creating this pull request. -->
Resolves #9 by @shnizzedy 

## Description
<!-- Concisely describe what the pull request does. -->
Currently if we click Monthly Hack-a-day tab, it'll download a calendar without showing event information. The event information is added in this branch.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Change url from calendar invite to a markdown file (_pages/hack.md) with event information.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
