### PR TITLE
Rename proceedings label in nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,7 +4,7 @@ main:
     url: "/about"
   - title: "Get Involved"
     url: "/engagement"
-  - title: "Proceedings"
+  - title: "Tools"
     url: "/proceedings"
   # - title: "About"
   #   url: https://mmistakes.github.io/minimal-mistakes/about/


### PR DESCRIPTION
## Resolves
Resolves #37 by @kaitj 

## Description
Changes the label from "Proceedings" to "Tools" in site nav.