### PR TITLE
Remove mention of gather and monthly meets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,12 +69,6 @@ footer:
     - label: GitHub
       icon: fab fa-fw fa-github
       url: https://github.com/nmind
-    - label: Gather
-      icon: fas fa-fw fa-city
-      url: https://gather.town/app/ESJPNXX7CVirKett/nmind
-    - label: Monthly Hack-a-day
-      icon: fas fa-fw fa-calendar
-      url: /assets/calendar/NMIND_monthly_meeting.ics
     - label: Mailing List
       icon: fas fa-fw fa-envelope
       url: https://groups.google.com/g/nmind

--- a/community_governance.md
+++ b/community_governance.md
@@ -29,7 +29,7 @@ model:
         <li>DEVELOPMENT TEAM leaders work with the EXECUTIVE LEADERSHIP and STRATEGIC COMMITTEE to set goals and provision resources.</li>
         <li>DEVELOPMENT TEAMS, made up of COMMUNITY members, work towards the established objectives and contribute results back to the COMMUNITY.</li>
       </ul>
-     
+
       <p>Each of the layers of the NMIND Governance model can be further defined as:</p>
       <ul>
         <li>The EXECUTIVE LEADERSHIP translates the strategic vision into prioritized action plans with responsibilities and deliverables distributed to the relevant DEVELOPMENT TEAM(S). The EXECUTIVE LEADERSHIP is responsible for designating, supporting and managing resources utilized in development.</li>
@@ -68,10 +68,8 @@ model:
             <li>The Structure of proposals is presently deliberately flexible, and will be further restricted based on learned experience.</li>
             <li>All proposals and projects will be public, and include instructions for how new members may engage with them.</li>
           </ul>
-          <li>To have voting privileges for STRATEGIC COMMITTEE selection, a COMMUNITY MEMBER is required to demonstrate participation in NMIND initiative discussions or monthly hackathons.</li>
+          <li>To have voting privileges for STRATEGIC COMMITTEE selection, a COMMUNITY MEMBER is required to demonstrate participation in NMIND initiative discussions.</li>
         </ul>
-
-
 ---
 
 {% include feature_row id="overview" type="full-width" %}

--- a/engagement.md
+++ b/engagement.md
@@ -11,9 +11,6 @@ get_involved:
   - excerpt: "### Software Contribution
 
 Check out one of our repositories on [GitHub](https://github.com/nmind). Feedback, questions, and contributions are always welcome!"
-  - excerpt: "### Hack-a-days
-
-Join us for monthly hack-a-days on Gather.town! Add [this](/assets/calendar/NMIND_monthly_meeting.ics) event to your calendar, and join us on the first Thursday of the month."
   
   - excerpt: "### Testing
 

--- a/proceedings.md
+++ b/proceedings.md
@@ -8,7 +8,7 @@ header:
   overlay_image: "https://images.rawpixel.com/image_1000/czNmcy1wcml2YXRlL3Jhd3BpeGVsX2ltYWdlcy93ZWJzaXRlX2NvbnRlbnQvbHIvdjg4MmJhdGNoMi1rdWwtMTRfMS5qcGc.jpg"
 
 upfront:
-  - excerpt: "A core objective of the NMIND Collaborative is the dissemination of community-focused standards, and the evaluation of tools. This Proceedings section, presently under construction, presents the results of such evaluations as they occur. With the long-term objective of establishing a robust peer-review process and relying upon opt-in participation to ensure developer consent, these evaluations currently take place at monthly NMIND Hackathons and focus on tools developed by community members. In future, automated approaches will simplify the review process, and the results presented here will include interactivity that support a deeper understanding of tools and how they relate to their users and one another. Please don't hesitate to reach out if you'd like to contribute to building this platform!"
+  - excerpt: "A core objective of the NMIND Collaborative is the dissemination of community-focused standards, and the evaluation of tools. This Proceedings section, presently under construction, presents the results of such evaluations as they occur. With the long-term objective of establishing a robust peer-review process and relying upon opt-in participation to ensure developer consent, these evaluations currently focus on tools developed by community members. In future, automated approaches will simplify the review process, and the results presented here will include interactivity that support a deeper understanding of tools and how they relate to their users and one another. Please don't hesitate to reach out if you'd like to contribute to building this platform!"
 
 summary:
   - image_path: /assets/images/example_portal.png
@@ -24,8 +24,6 @@ redirects:
   - excerpt: "### Feedback"
     url: "https://github.com/nmind/standards-checklist/issues/new"
     btn_label: "&#187; Help us improve with your suggestions"
-    
-
 ---
 
 {% include feature_row id="upfront" type="full" %}
@@ -33,4 +31,3 @@ redirects:
 {% include feature_row id="summary" type="full" %}
 
 {% include feature_row id="redirects" %}
-


### PR DESCRIPTION
## Resolves
Resolves #39.

## Description
Removes associated gathertown links and updates associated text across the pages. Can revisit in the future if we want to set up something new in the future for a monthly.